### PR TITLE
README: Fix instructions numbering (1. -> 4.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Install
 
 3. Copy directory `memodump` into static files directory `MoinMoin/web/static/htdocs/`.
    Again location of that directory will vary. It could be:
-
     * `/usr/share/moin/htdocs` if you installed MoinMoin from Ubuntu package
     * `/usr/local/lib/python2.7/dist-packages/MoinMoin/web/static/htdocs` if you installed MoinMoin from zip
     * and so on


### PR DESCRIPTION
The last installation step is labelled `4.` but GitHub's markdown parser thought it was the first item of another list, hence labelled it as `1.`
